### PR TITLE
fixed issue #1 by including a private constructor for Translator class

### DIFF
--- a/src/argouml-app/src/org/argouml/cognitive/Translator.java
+++ b/src/argouml-app/src/org/argouml/cognitive/Translator.java
@@ -48,6 +48,10 @@ package org.argouml.cognitive;
  */
 public class Translator {
 
+    private Translator(){
+        throw new IllegalStateException("Utility class");
+    }
+
     private static AbstractCognitiveTranslator translator;
 
     /**


### PR DESCRIPTION
Pull request:
resolved #1 to remove intentionality technical debt by adding a private constructor to a utility class to remove the ability to instantiate.

Location: Translator.java
Path: src/argouml-app/src/org/argouml/cognitive/Translator.java
