### PR TITLE
fixed issue #3 by renaming ActionNewException class to ActionNew

### DIFF
--- a/src/argouml-app/src/org/argouml/uml/ui/behavior/common_behavior/ActionNew.java
+++ b/src/argouml-app/src/org/argouml/uml/ui/behavior/common_behavior/ActionNew.java
@@ -53,12 +53,12 @@ import org.argouml.uml.ui.AbstractActionNewModelElement;
  *
  * @author Tom Morris
  */
-public class ActionNewException extends AbstractActionNewModelElement {
+public class ActionNew extends AbstractActionNewModelElement {
 
     /**
      * The constructor.
      */
-    public ActionNewException() {
+    public ActionNew() {
         super("button.new-exception");
         putValue(Action.NAME, Translator.localize("button.new-exception"));
     }


### PR DESCRIPTION
Pull request:
resolved #3 by renaming ActionNewException class to Exception to follow the class naming standard as this class does not extend Exception class.

Location:
ActionNew.java

Path: src/argouml-app/src/org/argouml/uml/ui/behavior/common_behavior/ActionNew.java