### PR TITLE
Fixed Issue 6#  Replace the type specification in this constructor call with the diamond operator ("<>").

### DIFF
--- a/src/argouml-app/src/org/argouml/application/Main.java
+++ b/src/argouml-app/src/org/argouml/application/Main.java
@@ -127,7 +127,8 @@ public class Main {
     private static final String DEFAULT_MODEL_IMPLEMENTATION =
         "org.argouml.model.mdr.MDRModelImplementation";
 
-    private static List<Runnable> postLoadActions = new ArrayList<Runnable>();
+    private static List<Runnable> postLoadActions = new ArrayList<>();
+
 
     private static boolean doSplash = true;
 


### PR DESCRIPTION
This pull request addresses Issue #6 by refactoring the constructor call to use the diamond operator (<>) instead of specifying the type explicitly. The diamond operator enhances code readability and reduces redundancy by allowing the compiler to infer the type, aligning the code with modern Java best practices.

Path to file: src/argouml-app/src/org/argouml/application/Main.java

Issue link: 
https://github.com/dashi1601/argoumlFall2024/issues/9#issue-2584363677
